### PR TITLE
feat(cors-api): enable CORS for React Vite frontend with rack-cors gem

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -42,7 +42,7 @@ gem "jwt"
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
-# gem "rack-cors"
+gem "rack-cors"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -200,6 +200,9 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.1)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -336,6 +339,7 @@ DEPENDENCIES
   letter_opener
   pg (~> 1.1)
   puma (>= 5.0)
+  rack-cors
   rails (~> 8.0.2, >= 8.0.2.1)
   rubocop-rails-omakase
   solid_cable

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -20,6 +20,19 @@ module Backend
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    # Configuration for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+      origins Rails.env.development? ? 'http://localhost:5173' : 'https://your-frontend-domain.com'
+
+      resource '*',
+        headers: :any,
+        methods: [:get, :post, :put, :patch, :delete, :options, :head],
+        expose: ['Authorization'], # if you want frontend to read Authorization header
+        credentials: true # required for cookies/sessions — but you’re using JWT, so optional
+      end
+    end
+    
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
Configuration for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible